### PR TITLE
chore: update pnpm to 11.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,5 @@
     "prettier": "^3.9.6",
     "typescript": "^7.0.2"
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.15.1"
 }


### PR DESCRIPTION
## 修改

- 将项目使用的 pnpm 固定到 11.15.1。
- 同步相关 CI、部署配置或文档中的 pnpm 版本。

## 验证

- pnpm 11.15.1 冻结安装通过。
- 本地构建或对应的类型检查通过。
